### PR TITLE
chore: use PAT in relases

### DIFF
--- a/.github/workflows/realease.yml
+++ b/.github/workflows/realease.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: simple


### PR DESCRIPTION
add PAT for release.yml instead of GITHUB_TOKEN