### PR TITLE
fix: use only upstream provided binary compilers as GP

### DIFF
--- a/.github/workflows/scripts/config.sh
+++ b/.github/workflows/scripts/config.sh
@@ -4,5 +4,5 @@ build_dir=/tmp/build
 prefix=${build_dir}/tcc-root
 ln_location=${build_dir}/tcc-root
 extra_flags="-s"
-trusted_compilers="gcc clang"
+trusted_compilers="gcc clang tcc"
 src_a_dir="/tmp/src_a"

--- a/.github/workflows/scripts/ddc.sh
+++ b/.github/workflows/scripts/ddc.sh
@@ -40,8 +40,6 @@ Performing DDC with...
 Untrusted src dir: ${src_a_dir}
 Trusted compilers: ${trusted_compilers}
 EOF
-# self-regeneration of untrusted compiler
-$cwd/.github/workflows/scripts/double-compile.sh ${build_dir}/gcc-tcc/bin/tcc $src_a_dir
 # ddc process
 for trusted_compiler in ${trusted_compilers}; do
   $cwd/.github/workflows/scripts/double-compile.sh $trusted_compiler $src_a_dir

--- a/shell.nix
+++ b/shell.nix
@@ -11,6 +11,7 @@ pkgs.mkShell {
     wget
     perl
     texinfoInteractive
+    tinycc
   ];
   shellHook = ''
     export STAGE1_CONF="--crtprefix=${lib.getLib pkgs.stdenv.cc.libc}/lib --sysincludepaths=${lib.getDev pkgs.stdenv.cc.libc}/include:{B}/include --libpaths={B}:${lib.getLib pkgs.stdenv.cc.libc}/lib"


### PR DESCRIPTION
Use only binaries from Nix packages in DDC process